### PR TITLE
Add Attic nix cache at nix-cache.stevedores.org

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,11 @@
 {
   description = "Stevedores.org - AI Agent Packaging Platform";
 
+  nixConfig = {
+    extra-substituters = [ "https://nix-cache.stevedores.org/stevedores" ];
+    extra-trusted-substituters = [ "https://nix-cache.stevedores.org/stevedores" ];
+  };
+
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
@@ -31,6 +36,7 @@
             nodejs_22
 
             # Tools
+            attic-client
             cargo-watch
             just
 
@@ -46,6 +52,10 @@
             echo "  cd frontend && bun install && bun run dev  # Start web server"
             echo "  cd crate-ai-engine && cargo test           # Test Rust code"
             echo "  cd crate-ai-engine && wasm-pack build      # Build WASM"
+            echo ""
+            echo "Nix Cache (Attic):"
+            echo "  attic login stevedores https://nix-cache.stevedores.org \$ATTIC_TOKEN"
+            echo "  attic push stevedores <store-path>         # Push to cache"
             echo ""
           '';
 


### PR DESCRIPTION
## Summary
- Configure `flake.nix` with `nixConfig.extra-substituters` pointing to `https://nix-cache.stevedores.org/stevedores`
- Add `attic-client` to the dev shell for push/pull operations
- Document Attic login and push commands in the shell hook

## Context
Matches the Attic/R2 binary cache pattern used in [lornu.ai](https://github.com/lornu-ai/lornu.ai). This enables caching of Nix build artifacts (WASM module, dev shell closures) to speed up CI and developer onboarding.

## Test plan
- [ ] `nix develop` enters dev shell with `attic-client` available
- [ ] `attic --version` works inside dev shell
- [ ] `nix build .#wasm` can pull cached artifacts (once cache is populated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)